### PR TITLE
fixing decorator bug with mutations and client override

### DIFF
--- a/src/graphql.tsx
+++ b/src/graphql.tsx
@@ -184,6 +184,9 @@ export default function graphql<
 
         this.shouldRerender = true;
 
+        if (this.type === DocumentType.Mutation) {
+          return;
+        }
         if (this.client !== client && this.client !== nextContext.client) {
           if (client) {
             this.client = client;
@@ -198,9 +201,6 @@ export default function graphql<
           if (!this.shouldSkip(nextProps)) {
             this.subscribeToQuery();
           }
-          return;
-        }
-        if (this.type === DocumentType.Mutation) {
           return;
         }
         if (


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on React Apollo!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring React Apollo is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of React Apollo as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

This fixes a bug where a `graphql` decorator that wraps a `Mutation` and supplies a custom `client` override in the `options` causes `componentWillReceiveProps` to interpret the `document`/`operation` as a `Query` instead of a `Mutation`. We are simply moving the short-circuit for early return on `Mutation` up so that we check that condition before attempting to process as a `Query`.
