### PR TITLE
Apply https://github.com/apollographql/react-apollo/pull/1531

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "bundlesize": [
     {
       "path": "./lib/umd/react-apollo.js",
-      "maxSize": "4.7 KB"
+      "maxSize": "4.8 KB"
     }
   ],
   "lint-staged": {


### PR DESCRIPTION
Applies https://github.com/apollographql/react-apollo/pull/1531 from upstream.

This "bug" is currently blocking https://github.com/Shopify/web/issues/9365.

>This is a fairly minimal fix for React components ceasing to get updates after an error occurs in a query. It happens due to the way observables work.. they will terminate a subscription after the error handler is called. Without going through and reconsidering all of the subscription logic between react-apollo and the client, simply resubscribing on error seems like the simplest way to get it working again. A unit test was written to cover this scenario.

>Here is the most relevant issue:
apollographql/apollo-client#2513
I have seen several others which might be resolved with this fix.